### PR TITLE
Add proxy connection to WhatsApp

### DIFF
--- a/src/lib/components/proxyList/connectButton.svelte
+++ b/src/lib/components/proxyList/connectButton.svelte
@@ -14,7 +14,7 @@
 
 <style>
 	button {
-		background-color: #000;
+		background-color: #25D366;
 		color: #fff;
 		border: none;
 		border-radius: 5px;

--- a/src/lib/components/proxyList/connectButton.svelte
+++ b/src/lib/components/proxyList/connectButton.svelte
@@ -1,15 +1,15 @@
 <script lang="ts">
-	import type { ProxyType } from '$lib/typeDef/proxyType';
-	export let proxyEntry: ProxyType;
+	import type { ProxyServerApi } from '$lib/typeDef/proxyApiReponse';
+	export let proxyEntry: ProxyServerApi;
 
-	function connectToWhatsApp() {
-		const url = `https://wa.me/proxy?host=${proxyEntry.ip}&chatPort=${proxyEntry.port}&mediaPort=588&chatTLS=true`;
+	function connectToWhatsapp() {
+		const url = `https://wa.me/proxy?host=${proxyEntry.ipAddress}&chatPort=${proxyEntry.proxyPort}&mediaPort=588&chatTLS=true`;
 		window.location.href = url;
 	}
 </script>
 
 <div>
-	<button on:click={connectToWhatsApp}>Connect</button>
+	<button on:click={connectToWhatsapp}>Connect</button>
 </div>
 
 <style>
@@ -22,16 +22,15 @@
 		font-size: 1rem;
 		font-weight: 500;
 		cursor: pointer;
-		transition: transform 0.2s, box-shadow 0.2s;
+		box-shadow: 0 4px #999;
 	}
 
 	button:hover {
-		transform: translateY(-2px);
-		box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+		background-color: #128C7E;
 	}
 
 	button:active {
+		box-shadow: 0 2px #666;
 		transform: translateY(2px);
-		box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
 	}
 </style>

--- a/src/lib/components/proxyList/connectButton.svelte
+++ b/src/lib/components/proxyList/connectButton.svelte
@@ -15,7 +15,7 @@
 <style>
 	button {
 		background-color: #25D366;
-		color: #fff;
+		color: #000;
 		border: none;
 		border-radius: 5px;
 		padding: 0.5rem 1rem;

--- a/src/lib/components/proxyList/connectButton.svelte
+++ b/src/lib/components/proxyList/connectButton.svelte
@@ -1,10 +1,15 @@
 <script lang="ts">
 	import type { ProxyType } from '$lib/typeDef/proxyType';
 	export let proxyEntry: ProxyType;
+
+	function connectToWhatsApp() {
+		const url = `https://wa.me/proxy?host=${proxyEntry.ip}&chatPort=${proxyEntry.port}&mediaPort=588&chatTLS=true`;
+		window.location.href = url;
+	}
 </script>
 
 <div>
-	<button>Connect</button>
+	<button on:click={connectToWhatsApp}>Connect</button>
 </div>
 
 <style>

--- a/src/lib/components/proxyList/connectButton.svelte
+++ b/src/lib/components/proxyList/connectButton.svelte
@@ -22,5 +22,16 @@
 		font-size: 1rem;
 		font-weight: 500;
 		cursor: pointer;
+		transition: transform 0.2s, box-shadow 0.2s;
+	}
+
+	button:hover {
+		transform: translateY(-2px);
+		box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+	}
+
+	button:active {
+		transform: translateY(2px);
+		box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
 	}
 </style>

--- a/src/lib/components/proxyList/proxyEntry.svelte
+++ b/src/lib/components/proxyList/proxyEntry.svelte
@@ -75,6 +75,7 @@
 	{:else}
 		<td>Pinging...</td>
 	{/if}
+	<td><ConnectButton {proxyEntry} /></td>
 </tr>
 
 <style>

--- a/src/lib/typeDef/proxyApiReponse.ts
+++ b/src/lib/typeDef/proxyApiReponse.ts
@@ -15,4 +15,5 @@ export interface ProxyServerApi {
 	createdAt: string;
 	updatedAt: string;
 	responseTime?: number;
+	lastChecked?: string;
 }


### PR DESCRIPTION
Fixes #229

Implement a proxy connection to WhatsApp using the provided URL.

* **ConnectButton Component**
  - Add a function to navigate to the provided proxy URL.
  - Update the button's `on:click` event to call the new function.

* **ProxyEntry Component**
  - Import the `ConnectButton` component.
  - Add the `ConnectButton` component to the table row.
  - Pass the `proxyEntry` prop to the `ConnectButton` component.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/WhatsApp-Proxy/whatsapp-proxies-web/issues/229?shareId=372f3bdb-707f-43bc-8035-0d554ced555d).